### PR TITLE
display difference in code coverage when the difference is 0. 

### DIFF
--- a/src/construct-comment.ts
+++ b/src/construct-comment.ts
@@ -5,7 +5,7 @@ import { getCoverageDifferenceEmoji, getCoverageEmoji, getCoverageAfterPr } from
 const constructComment = async (commentData: CommentData): Promise<string> => {
   let message: string;
 
-  if(commentData.lines.diff) {
+  if(commentData.lines.diff === 0 || commentData.lines.diff) {
     message = `
 ## Code Coverage
 

--- a/src/construct-comment.ts
+++ b/src/construct-comment.ts
@@ -5,7 +5,7 @@ import { getCoverageDifferenceEmoji, getCoverageEmoji, getCoverageAfterPr } from
 const constructComment = async (commentData: CommentData): Promise<string> => {
   let message: string;
 
-  if(commentData.lines.diff === 0 || commentData.lines.diff) {
+  if(commentData.lines.diff >= 0) {
     message = `
 ## Code Coverage
 

--- a/src/construct-comment.ts
+++ b/src/construct-comment.ts
@@ -13,7 +13,7 @@ const constructComment = async (commentData: CommentData): Promise<string> => {
 |-----------|----------------------------------------------|-------------------------------------------------------------------|--------------------------------------------------------------- |
 | Lines     | ${commentData.lines.percent.toFixed(2)}%     | ${getCoverageAfterPr(commentData.lines.percent, commentData.lines.diff)}      | ${getCoverageDifferenceEmoji(commentData.lines.diff)}     |
 | Functions | ${commentData.functions.percent.toFixed(2)}% | ${getCoverageAfterPr(commentData.functions.percent, commentData.functions.diff)}  | ${getCoverageDifferenceEmoji(commentData.functions.diff)} |
-| Branches  | ${commentData.branches.percent.toFixed(2)}%  | $${getCoverageAfterPr(commentData.branches.percent, commentData.branches.diff)}   | ${getCoverageDifferenceEmoji(commentData.branches.diff)}  |
+| Branches  | ${commentData.branches.percent.toFixed(2)}%  | ${getCoverageAfterPr(commentData.branches.percent, commentData.branches.diff)}   | ${getCoverageDifferenceEmoji(commentData.branches.diff)}  |
 <!-- coverage-action-comment -->
 `;
   } else {

--- a/src/construct-comment.ts
+++ b/src/construct-comment.ts
@@ -5,7 +5,7 @@ import { getCoverageDifferenceEmoji, getCoverageEmoji, getCoverageAfterPr } from
 const constructComment = async (commentData: CommentData): Promise<string> => {
   let message: string;
 
-  if(commentData.lines.diff >= 0) {
+  if(commentData.lines.diff === 0 || commentData.lines.diff) {
     message = `
 ## Code Coverage
 

--- a/src/construct-comment.ts
+++ b/src/construct-comment.ts
@@ -5,7 +5,7 @@ import { getCoverageDifferenceEmoji, getCoverageEmoji, getCoverageAfterPr } from
 const constructComment = async (commentData: CommentData): Promise<string> => {
   let message: string;
 
-  if(commentData.lines.diff === 0 || commentData.lines.diff) {
+  if(commentData.lines.diff) {
     message = `
 ## Code Coverage
 


### PR DESCRIPTION
### TICKET
[sc92587](https://app.shortcut.com/neofinancial/story/92587/comment-on-github-action-logs-undefined-for-coverage-difference-yet-properly-uploads-the-coverage)
### CHANGES
0 was read as a falsey value and did not generate comment with difference displayed. Allowed difference to be 0 and still generate comment.

BEFORE
<img width="706" alt="Screen Shot 2022-03-21 at 7 15 30 PM" src="https://user-images.githubusercontent.com/59579748/159388241-c3da543f-b310-4305-9336-533374f5806a.png">

AFTER
<img width="706" alt="Screen Shot 2022-03-21 at 7 13 44 PM" src="https://user-images.githubusercontent.com/59579748/159388243-551a1b07-6b5b-4553-8f28-73369ca541ec.png">

