### PR TITLE
Runs actions on eks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: neo-x86-medium
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 12
           cache: npm

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: neo-x86-medium
     permissions:
       actions: read
       contents: read
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -14,13 +14,13 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: neo-x86-medium
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,11 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: neo-x86-medium
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
           cache: npm


### PR DESCRIPTION
# What Has Changed?
We\'re moving away from GitHub hosted actions runners to running actions on our own Elastic Kubernetes Service (EKS) cluster.
The switch to an EKS environment enables us to manage our environment more effectively, gives us greater control over security measures, optimizes resource utilization, and importantly, ensures cost-efficiency. With EKS, we have the advantage of pricing based on our actual compute resource usage rather than the duration of operations.
This pull request moves all possible actions to run on EKS.