### PR TITLE
ENGDX-543: set action to default ignore dependabot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Coverage Upload Action Changelog
 
+## 2.1.1 (April 9, 2024)
+
+- Updated handling for ignoredUsers to always ignore 'dependabot'
+
 ## 2.1.0 (April 9, 2024)
 
-- Added optional input ignoredUsers. ignoredUsers is a comma separated string of authors which will not run this action. Defaulted to just 'dependabot'
+- Added optional input ignoredUsers. ignoredUsers is a comma separated string of authors which will not run this action
 
 ## 2.0.0 (May 18, 2022)
 

--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ jobs:
 
 If you have an existing workflow that runs your tests you can just add the `Upload coverage` step at the end of that workflow.
 
-If you want to exclude certain authors from running this action update the ignoreUsers input as seen below
+If you want to exclude certain authors from running this action update the ignoreUsers input as seen below. Dependabot is already ignored by default
 
 ```
   ...
   with:
     coverageEndpoint: https://your.endpoint.here
     coverageToken: ${{ secrets.COVERAGE_TOKEN }}
-    ignoredUsers: 'dependabot,ignoredUser1,ignoredUser2' // <--- Update here
+    ignoredUsers: 'ignoredUser1,ignoredUser2' // <--- Update here
   ...
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coverage-upload-action",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "coverage-upload-action",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,10 @@ const run = async (): Promise<void> => {
       .split(',')
       .map((user) => user.trim());
 
-    console.log(ignoredUsers);
-
     const author = context.payload.pull_request?.user.login;
+
+    console.log(ignoredUsers);
+    console.log(author);
 
     if (author === 'dependabot' || ignoredUsers.includes(author)) {
       console.log(`Skipping the action because the pull request is created by ${author}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,12 @@ const run = async (): Promise<void> => {
       .split(',')
       .map((user) => user.trim());
 
-    if (ignoredUsers.includes(context.payload.pull_request?.user.login)) {
-      console.log(
-        `Skipping the action because the pull request is created by ${context.payload.pull_request?.user.login}`
-      );
+    console.log(ignoredUsers)
+
+    const author = context.payload.pull_request?.user.login;
+
+    if (author === 'dependabot' || ignoredUsers.includes(author)) {
+      console.log(`Skipping the action because the pull request is created by ${author}`);
 
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ const run = async (): Promise<void> => {
       .split(',')
       .map((user) => user.trim());
 
-    console.log(ignoredUsers)
+    console.log(ignoredUsers);
 
     const author = context.payload.pull_request?.user.login;
 


### PR DESCRIPTION
dependabot PR's are package.json and lock file changes only, these do not impact coverage and should be ignored by default