### PR TITLE
ENGDX-543: ignore dependabot[bot]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Coverage Upload Action Changelog
 
+## 2.1.1 (April 19, 2024)
+
+- Updated default ignoredUsers to dependabot[bot]
+
 ## 2.1.0 (April 9, 2024)
 
 - Added optional input ignoredUsers. ignoredUsers is a comma separated string of authors which will not run this action. Defaulted to just 'dependabot'

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     required: false
   ignoredUsers:
     description: 'disable action to run on specified users PRs'
-    default: 'dependabot'
+    default: 'dependabot[bot]'
     required: false
 runs:
   using: 'node16'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coverage-upload-action",
-  "version": "2.0.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "coverage-upload-action",
-      "version": "2.0.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coverage-upload-action",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Parses coverage file and uploads to remote endpoint",
   "author": "Neo Financial Engineering",
   "license": "MIT",


### PR DESCRIPTION
dependabot PR's are package/lock file changes only, these do not impact coverage and should be ignored by default. The ignoredUsers default value looks like it is not the same as the login value github gives @dependabot 